### PR TITLE
Fix/refactor navigation flag

### DIFF
--- a/app/src/androidTest/java/com/sdp/movemeet/view/activity/UploadActivityActivityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/activity/UploadActivityActivityTest.java
@@ -32,6 +32,7 @@ import com.sdp.movemeet.backend.serialization.BackendSerializer;
 import com.sdp.movemeet.models.Activity;
 import com.sdp.movemeet.view.activity.UploadActivityActivity;
 import com.sdp.movemeet.view.main.MainActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 import com.sdp.movemeet.view.navigation.security.MainActivitySecurityTest;
 
 import org.hamcrest.Matcher;
@@ -89,8 +90,7 @@ public class UploadActivityActivityTest {
     @Before
     public void setup() {
         // Disable navigation for tests
-        UploadActivityActivity.enableNav = false;
-        MainActivity.enableNav = false;
+        Navigation.profileField = false;
 
         // Set up mocks and their behaviors
         // Set up fake database

--- a/app/src/androidTest/java/com/sdp/movemeet/view/chat/ChatActivityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/chat/ChatActivityTest.java
@@ -23,10 +23,12 @@ import com.google.firebase.database.ValueEventListener;
 import com.sdp.movemeet.R;
 import com.sdp.movemeet.view.chat.ChatActivity;
 import com.sdp.movemeet.view.main.MainActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +59,7 @@ public class ChatActivityTest {
 
     @Test
     public void chatActivityTest() {
-        ChatActivity.enableNav = false;
+        Navigation.profileField = false;
         CountDownLatch latch = new CountDownLatch(1);
 
         fAuth = FirebaseAuth.getInstance();

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/NavigationTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/NavigationTest.java
@@ -71,11 +71,6 @@ public class NavigationTest {
     @Before
     public void signIn(){
         Navigation.profileField = false;
-        MainActivity.enableNav = true;
-        UploadActivityActivity.enableNav = true;
-        ActivityDescriptionActivity.enableNav = true;
-        ChatActivity.enableNav = true;
-        ProfileActivity.enableNav = true;
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -210,13 +205,13 @@ public class NavigationTest {
         try{
             Thread.sleep(500);
         }catch(Exception e){}
-        Intents.release();
 
     }
 
-    /*@After
+    @After
     public void SignOut() {
-        fAuth.signOut();
-    }*/
+        Intents.release();
+        //fAuth.signOut();
+    }
 }
 

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ActivityDescriptionSecurityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ActivityDescriptionSecurityTest.java
@@ -9,6 +9,7 @@ import com.sdp.movemeet.R;
 import com.sdp.movemeet.view.activity.ActivityDescriptionActivity;
 import com.sdp.movemeet.view.chat.ChatActivity;
 import com.sdp.movemeet.view.main.MainActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,7 +33,7 @@ public class ActivityDescriptionSecurityTest {
 
     @Test
     public void redirectionTest() {
-        ActivityDescriptionActivity.enableNav = false;
+        Navigation.profileField = false;
         ActivityScenario scenario = ActivityScenario.launch(ActivityDescriptionActivity.class);
 
         try {

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ChatActivitySecurityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ChatActivitySecurityTest.java
@@ -10,6 +10,7 @@ import com.sdp.movemeet.R;
 
 import com.sdp.movemeet.view.activity.ActivityDescriptionActivity;
 import com.sdp.movemeet.view.chat.ChatActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,7 +34,7 @@ public class ChatActivitySecurityTest {
 
     @Test
     public void redirectionTest() {
-        ChatActivity.enableNav = false;
+        Navigation.profileField = false;
         ActivityScenario scenario = ActivityScenario.launch(ChatActivity.class);
 
         try {

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/MainActivitySecurityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/MainActivitySecurityTest.java
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.sdp.movemeet.R;
 import com.sdp.movemeet.view.activity.ActivityDescriptionActivity;
 import com.sdp.movemeet.view.main.MainActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,7 +32,7 @@ public class MainActivitySecurityTest {
 
     @Test
     public void redirectionTest() {
-        MainActivity.enableNav = false;
+        Navigation.profileField = false;
         ActivityScenario scenario = ActivityScenario.launch(MainActivity.class);
 
         try {

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ProfileActivitySecurityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/ProfileActivitySecurityTest.java
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.auth.FirebaseAuth;
 import com.sdp.movemeet.R;
 import com.sdp.movemeet.view.activity.ActivityDescriptionActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 import com.sdp.movemeet.view.profile.ProfileActivity;
 
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class ProfileActivitySecurityTest {
 
     @Test
     public void redirectionTest() {
-        ProfileActivity.enableNav = false;
+        Navigation.profileField = false;
         ActivityScenario scenario = ActivityScenario.launch(ProfileActivity.class);
 
         try {

--- a/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/UploadActivitySecurityTest.java
+++ b/app/src/androidTest/java/com/sdp/movemeet/view/navigation/security/UploadActivitySecurityTest.java
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.sdp.movemeet.R;
 import com.sdp.movemeet.view.activity.ActivityDescriptionActivity;
 import com.sdp.movemeet.view.activity.UploadActivityActivity;
+import com.sdp.movemeet.view.navigation.Navigation;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,7 +34,7 @@ public class UploadActivitySecurityTest {
 
     @Test
     public void redirectionTest() {
-        UploadActivityActivity.enableNav = false;
+        Navigation.profileField = false;
         ActivityScenario scenario = ActivityScenario.launch(UploadActivityActivity.class);
 
         try {

--- a/app/src/main/java/com/sdp/movemeet/models/Activity.java
+++ b/app/src/main/java/com/sdp/movemeet/models/Activity.java
@@ -1,11 +1,13 @@
 package com.sdp.movemeet.models;
 
+import com.google.android.gms.maps.model.LatLng;
 import com.google.firebase.firestore.DocumentReference;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -15,7 +17,7 @@ import java.util.Locale;
  *
  * */
 
-public class Activity extends FirebaseObject implements Serializable {
+public class Activity implements Serializable, FirebaseObject {
 
     private final String activityId;
     private final String organizerId;
@@ -33,8 +35,6 @@ public class Activity extends FirebaseObject implements Serializable {
     private final Sport sport;
     private String address;
     private Date createdAt;
-
-    private DocumentReference backendRef;
 
     static  private SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault());
 
@@ -84,7 +84,7 @@ public class Activity extends FirebaseObject implements Serializable {
         this.longitude = longitude;
         this.latitude = latitude;
         this.description = description;
-        super.documentPath = documentPath;
+        this.documentPath = documentPath;
         this.date = date;
         this.duration = duration;
         this.sport = sport;
@@ -315,25 +315,6 @@ public class Activity extends FirebaseObject implements Serializable {
         return createdAt;
     }
 
-    /**
-     *
-     * @return a DocumentReference to the activity
-     */
-    public DocumentReference getBackendRef() {
-        return this.backendRef;
-    }
-
-    /**
-     * Sets the backend reference property if it was previously null, does nothing otherwise.
-     *
-     * @param newRef the new value used to reference this activity in its collection in the backend
-     * @return the DocumentReference used to reference this activity in its collection in the backend
-     */
-    public DocumentReference setBackendRef(DocumentReference newRef) throws IllegalArgumentException {
-        if (backendRef == null) backendRef = newRef;
-        return backendRef;
-    }
-
 
     @Override
     public String toString(){
@@ -362,4 +343,13 @@ public class Activity extends FirebaseObject implements Serializable {
 
     }
 
+    @Override
+    public String getDocumentPath() {
+        return this.documentPath;
+    }
+
+    @Override
+    public void setDocumentPath(String path) {
+        this.documentPath = path;
+    }
 }

--- a/app/src/main/java/com/sdp/movemeet/models/FirebaseObject.java
+++ b/app/src/main/java/com/sdp/movemeet/models/FirebaseObject.java
@@ -3,15 +3,12 @@ package com.sdp.movemeet.models;
 /**
  * An object that can be found in the Firebase Realtime Database/Firestore backend
  */
-public abstract class FirebaseObject {
+public interface FirebaseObject {
 
-    protected String documentPath;
     /**
      * @return The path of the document in the backend.
      */
-    public String getDocumentPath() {
-        return this.documentPath;
-    }
+    public String getDocumentPath();
 
     /**
      * Sets the path of the document in the backend.
@@ -19,8 +16,5 @@ public abstract class FirebaseObject {
      * @param path the path to attempt to set for the object.
      * @return the path of the object in the backend.
      */
-    public String setDocumentPath(String path) {
-        if (documentPath == null) documentPath = path;
-        return documentPath;
-    }
+    public void setDocumentPath(String path);
 }

--- a/app/src/main/java/com/sdp/movemeet/models/Message.java
+++ b/app/src/main/java/com/sdp/movemeet/models/Message.java
@@ -6,7 +6,7 @@ import java.util.Date;
 /**
  * This class represents a message
  */
-public class Message extends FirebaseObject {
+public class Message implements FirebaseObject {
     private String messageUser;
     private String messageText;
     private String messageUserId;
@@ -101,11 +101,11 @@ public class Message extends FirebaseObject {
 
 
     public String getDocumentPath() {
-        return super.documentPath;
+        return this.documentPath;
     }
 
-    public String setDocumentPath(String path) {
-        return super.setDocumentPath(path);
+    public void setDocumentPath(String path) {
+        this.documentPath = path;
     }
 
 }

--- a/app/src/main/java/com/sdp/movemeet/models/User.java
+++ b/app/src/main/java/com/sdp/movemeet/models/User.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
  *
  * */
 
-public class User extends FirebaseObject implements Serializable {
+public class User implements Serializable, FirebaseObject {
 
     private final String fullName;
     private final String email;
@@ -60,7 +60,7 @@ public class User extends FirebaseObject implements Serializable {
         this.description = description;
         this.idUser = idUser;
         this.imageId = imageId;
-        super.documentPath = documentPath;
+        this.documentPath = documentPath;
 
     }
 
@@ -155,11 +155,11 @@ public class User extends FirebaseObject implements Serializable {
     }
 
     public String getDocumentPath() {
-        return super.getDocumentPath();
+        return this.documentPath;
     }
 
-    public String setDocumentPath(String path) {
-        return super.setDocumentPath(path);
+    public void setDocumentPath(String path) {
+        this.documentPath = path;
     }
 
     @Override

--- a/app/src/main/java/com/sdp/movemeet/view/activity/ActivityDescriptionActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/activity/ActivityDescriptionActivity.java
@@ -60,9 +60,6 @@ public class ActivityDescriptionActivity extends AppCompatActivity {
     FirebaseAuth fAuth;
     private static final String TAG = "ActDescActivity";
 
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
-
     DrawerLayout drawerLayout;
     NavigationView navigationView;
     Toolbar toolbar;
@@ -119,7 +116,7 @@ public class ActivityDescriptionActivity extends AppCompatActivity {
             displayDescriptionActivityData();
         }
 
-        if(enableNav) new Navigation(this, R.id.nav_home).createDrawer();
+        if(Navigation.profileField) new Navigation(this, R.id.nav_home).createDrawer();
     }
 
 

--- a/app/src/main/java/com/sdp/movemeet/view/activity/ActivityListActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/activity/ActivityListActivity.java
@@ -27,25 +27,11 @@ import com.sdp.movemeet.R;
 
 public class ActivityListActivity extends AppCompatActivity {
 
-    /*
-    TextView fullName, email, phone;
-    FirebaseAuth fAuth;
-    FirebaseFirestore fStore;
-    String userId;
-
-    DrawerLayout drawerLayout;
-    NavigationView navigationView;
-    Toolbar toolbar;
-    TextView textView;*/
-
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_list);
 
-        if(enableNav) new Navigation(this, R.id.nav_list_activities).createDrawer();
+        if(Navigation.profileField) new Navigation(this, R.id.nav_list_activities).createDrawer();
     }
 }

--- a/app/src/main/java/com/sdp/movemeet/view/activity/UploadActivityActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/activity/UploadActivityActivity.java
@@ -52,8 +52,6 @@ public class UploadActivityActivity extends AppCompatActivity {
     @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
     public BackendManager<Activity> activityBackendManager;
 
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
 
     private Spinner spinner;
     private Calendar calendar;
@@ -120,7 +118,7 @@ public class UploadActivityActivity extends AppCompatActivity {
             }
         }
 
-        if (enableNav) new Navigation(this, R.id.nav_add_activity).createDrawer();
+        if (Navigation.profileField) new Navigation(this, R.id.nav_add_activity).createDrawer();
 
     }
 

--- a/app/src/main/java/com/sdp/movemeet/view/chat/ChatActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/chat/ChatActivity.java
@@ -55,9 +55,6 @@ import java.util.Date;
 
 public class ChatActivity extends AppCompatActivity {
 
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
-
     private static final String TAG = "ChatActivity";
     public static final String CHATS_CHILD = "chats";
 
@@ -147,7 +144,7 @@ public class ChatActivity extends AppCompatActivity {
 
         addExistingMessagesAndListenForNewMessages();
 
-        if(enableNav) new Navigation(this, R.id.nav_home).createDrawer();
+        if(Navigation.profileField) new Navigation(this, R.id.nav_home).createDrawer();
 
     }
 

--- a/app/src/main/java/com/sdp/movemeet/view/main/MainActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/main/MainActivity.java
@@ -26,9 +26,6 @@ import com.sdp.movemeet.view.navigation.Navigation;
 public class MainActivity extends AppCompatActivity {
     public static final String EXTRA_MESSAGE = "com.sdp.movemeet.MESSAGE";
 
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
-
     FirebaseAuth fAuth;
 
     @Override
@@ -43,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
             finish();
         }
 
-        if (enableNav) new Navigation(this, R.id.nav_home).createDrawer();
+        if (Navigation.profileField) new Navigation(this, R.id.nav_home).createDrawer();
 
     }
 }

--- a/app/src/main/java/com/sdp/movemeet/view/map/GPSRecordingActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/map/GPSRecordingActivity.java
@@ -48,6 +48,10 @@ public class GPSRecordingActivity extends FragmentActivity implements OnMapReady
     public boolean recording;
     private Button recButton;
 
+    private long time;
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public ArrayList<LatLng> path;
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     public SupportMapFragment supportMapFragment;
 
@@ -69,9 +73,6 @@ public class GPSRecordingActivity extends FragmentActivity implements OnMapReady
             updatePath(locationResult.getLastLocation());
         }
     };
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public ArrayList<LatLng> path;
 
 
     @Override

--- a/app/src/main/java/com/sdp/movemeet/view/profile/ProfileActivity.java
+++ b/app/src/main/java/com/sdp/movemeet/view/profile/ProfileActivity.java
@@ -49,12 +49,9 @@ public class ProfileActivity extends AppCompatActivity {
     public static final String EXTRA_MESSAGE_PHONE = "phone";
     public static final String EXTRA_MESSAGE_DESCRIPTION = "description";
 
-    @VisibleForTesting(otherwise=VisibleForTesting.PRIVATE)
-    public static boolean enableNav = true;
 
     ImageView profileImage;
     TextView fullName, email, phone, description;
-    TextView fullNameDrawer, emailDrawer, phoneDrawer;
     ProgressBar progressBar;
 
     String userId, userImagePath;
@@ -65,11 +62,6 @@ public class ProfileActivity extends AppCompatActivity {
     BackendManager<User> userManager;
     StorageReference storageReference;
     StorageReference profileRef;
-
-    DrawerLayout drawerLayout;
-    NavigationView navigationView;
-    Toolbar toolbar;
-    TextView textView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -100,7 +92,7 @@ public class ProfileActivity extends AppCompatActivity {
             loadRegisteredUserProfilePicture();
         }
 
-        if(enableNav) new Navigation(this, R.id.nav_edit_profile).createDrawer();
+        if(Navigation.profileField) new Navigation(this, R.id.nav_edit_profile).createDrawer();
 
     }
 


### PR DESCRIPTION
Instead of using `enableNav` on a per-class basis to enable/disable navigation during tests, we use a single boolean flag `profileField` in the `Navigation` activity.